### PR TITLE
Report completion of all jobs in GitHub Actions with status check

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,4 +59,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: void
-        run: echo
+        run: ""

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,4 +59,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: void
-        run:
+        run: echo

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,6 +56,7 @@ jobs:
   complete:
     name: Complete GitHub Actions
     needs: [lint, unit_test, docs_test]
+    runs-on: ubuntu-latest
     steps:
       - name: void
         run: echo

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,4 +57,6 @@ jobs:
     name: Complete GitHub Actions
     needs: [lint, unit_test, docs_test]
     runs-on: ubuntu-latest
-    steps: []
+    steps:
+      - name: void
+        run: echo

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,6 +57,4 @@ jobs:
     name: Complete GitHub Actions
     needs: [lint, unit_test, docs_test]
     runs-on: ubuntu-latest
-    steps:
-      - name: void
-        run: echo
+    steps: []

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,7 +54,7 @@ jobs:
         run: npm ci
       - run: npm run test:readme
   complete:
-    name: Complete GitHub Actions
+    name: GitHub Actions / Complete
     needs: [lint, unit_test, docs_test]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -58,5 +58,3 @@ jobs:
     needs: [lint, unit_test, docs_test]
     runs-on: ubuntu-latest
     steps:
-      - name: void
-        run: echo

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -58,3 +58,5 @@ jobs:
     needs: [lint, unit_test, docs_test]
     runs-on: ubuntu-latest
     steps:
+      - name: void
+        run: echo

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,4 +59,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: void
-        run: echo
+        run:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,3 +56,6 @@ jobs:
   complete:
     name: Complete GitHub Actions
     needs: [lint, unit_test, docs_test]
+    steps:
+      - name: void
+        run: echo

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,3 +53,6 @@ jobs:
       - name: Install Dependencies
         run: npm ci
       - run: npm run test:readme
+  complete:
+    name: Complete GitHub Actions
+    needs: [lint, unit_test, docs_test]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@
 
 * [#19] - Fix GitHub Actions trigger
 * [#20] - Update linter rules and package settings
+* [#22] - Report completion of all jobs in GitHub Actions with status check
 
 [Unreleased]: https://github.com/sounisi5011/readme-generator/compare/v0.0.2...master
 [#19]: https://github.com/sounisi5011/readme-generator/pull/19
 [#21]: https://github.com/sounisi5011/readme-generator/pull/21
 [#20]: https://github.com/sounisi5011/readme-generator/pull/20
+[#22]: https://github.com/sounisi5011/readme-generator/pull/22
 
 ## [0.0.2] - 2020-05-28 UTC
 

--- a/tests/cli/no-options.ts
+++ b/tests/cli/no-options.ts
@@ -39,9 +39,4 @@ describe('no options', () => {
 
         await expect(fileEntryExists(cwd, 'README.md')).resolves.toBe(false);
     });
-
-    // TODO: Remove this test
-    it('fail if node 12.x', () => {
-        expect(process.version).not.toMatch(/^v?12\./);
-    });
 });

--- a/tests/cli/no-options.ts
+++ b/tests/cli/no-options.ts
@@ -39,4 +39,9 @@ describe('no options', () => {
 
         await expect(fileEntryExists(cwd, 'README.md')).resolves.toBe(false);
     });
+
+    // TODO: Remove this test
+    it('fail if node 12.x', () => {
+        expect(process.version).not.toMatch(/^v?12\./);
+    });
 });


### PR DESCRIPTION
GitHub Actions status checks are created individually for each job.
However, there is no status check to report that all jobs have completed.

The title of the status check changes with each version of Node.js, so you have to change the settings of the protected branch on GitHub every time you change the supported Node.js.
To avoid this hassle, add a job that reports that all jobs have completed.