### PR TITLE
Move "@types/diff" package from "dependencies" field to "devDependencies" field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,12 +29,14 @@
 
 #### dependencies
 
-* [#50] - `@types/diff@^4.0.2`
+* ~~[#50] - `@types/diff@^4.0.2`~~
+    *moved to `devDependencies` by [#55]*
 * [#50] - `chalk@^4.1.0`
 * [#50] - `diff@^4.0.2`
 
 #### devDependencies
 
+* [#50], [#55] - `@types/diff@4.0.2`
 * [#45] - `@types/semver@7.3.1`
 * [#45] - `expect@26.1.0`
 * [#46] - `jest-extended@0.11.5`
@@ -62,6 +64,7 @@
 [#50]: https://github.com/sounisi5011/readme-generator/pull/50
 [#51]: https://github.com/sounisi5011/readme-generator/pull/51
 [#54]: https://github.com/sounisi5011/readme-generator/pull/54
+[#55]: https://github.com/sounisi5011/readme-generator/pull/55
 
 ## [0.0.4] - 2020-06-13 UTC
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1084,7 +1084,8 @@
     "@types/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-mIenTfsIe586/yzsyfql69KRnA75S8SVXQbTLpDejRrjH0QSJcpu3AUOi/Vjnt9IOsXKxPhJfGpQUNMueIU1fQ=="
+      "integrity": "sha512-mIenTfsIe586/yzsyfql69KRnA75S8SVXQbTLpDejRrjH0QSJcpu3AUOi/Vjnt9IOsXKxPhJfGpQUNMueIU1fQ==",
+      "dev": true
     },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   },
   "dependencies": {
     "@npmcli/git": "^2.0.2",
-    "@types/diff": "^4.0.2",
     "bent": "^7.3.2",
     "cac": "^6.5.10",
     "chalk": "^4.1.0",
@@ -71,6 +70,7 @@
   "devDependencies": {
     "@dprint/core": "0.9.0",
     "@types/bent": "7.3.0",
+    "@types/diff": "4.0.2",
     "@types/hosted-git-info": "3.0.0",
     "@types/jest": "26.0.0",
     "@types/node": "*",


### PR DESCRIPTION
This package does not include any type definition files. Therefore, there is no need to include a package for type definitions as a dependency.