### PR TITLE
chore(renovate): combine multiple dependencies into one PR

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -14,8 +14,6 @@
     },
     {
       "packageNames": [
-        "@dprint/core",
-        "dprint-plugin-typescript",
         "husky",
         "lint-staged",
         "prettier",
@@ -48,10 +46,7 @@
     {
       "packageNames": [
         "check-peer-deps",
-        "git-branch-is",
-        "is-git-status-clean",
         "npm-run-all",
-        "package-version-git-tag",
         "patch-package",
         "rimraf"
       ],

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,3 +1,62 @@
 {
-  "extends": ["config:js-lib", ":semanticCommits"]
+  "extends": ["config:js-lib", ":semanticCommits"],
+  "ignoreDeps": ["@types/node"],
+  "packageRules": [
+    {
+      "packageNames": ["eslint"],
+      "packagePatterns": [
+        "^@typescript-eslint/",
+        "^eslint-config-",
+        "^eslint-plugin-"
+      ],
+      "groupName": "dependencies: eslint packages",
+      "groupSlug": "eslint-packages"
+    },
+    {
+      "packageNames": [
+        "@dprint/core",
+        "dprint-plugin-typescript",
+        "husky",
+        "lint-staged",
+        "prettier",
+        "prettier-package-json",
+        "sort-package-json"
+      ],
+      "groupName": "dependencies: code formatter packages",
+      "groupSlug": "code-formatter-packages"
+    },
+    {
+      "packageNames": [
+        "escape-string-regexp",
+        "expect",
+        "jest",
+        "@types/jest",
+        "jest-extended",
+        "make-dir",
+        "omit.js",
+        "@types/rimraf",
+        "semver",
+        "@types/semver",
+        "strip-ansi",
+        "ts-jest",
+        "type-fest",
+        "typescript-cached-transpile"
+      ],
+      "groupName": "dependencies: test packages",
+      "groupSlug": "tester-packages"
+    },
+    {
+      "packageNames": [
+        "check-peer-deps",
+        "git-branch-is",
+        "is-git-status-clean",
+        "npm-run-all",
+        "package-version-git-tag",
+        "patch-package",
+        "rimraf"
+      ],
+      "groupName": "dependencies: npm-scripts packages",
+      "groupSlug": "npm-scripts-packages"
+    }
+  ]
 }

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -13,6 +13,11 @@
       "groupSlug": "eslint-packages"
     },
     {
+      "packageNames": ["commitizen", "cz-conventional-changelog"],
+      "groupName": "commitizen packages",
+      "groupSlug": "commitizen-packages"
+    },
+    {
       "packageNames": [
         "husky",
         "lint-staged",

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -9,7 +9,7 @@
         "^eslint-config-",
         "^eslint-plugin-"
       ],
-      "groupName": "dependencies: eslint packages",
+      "groupName": "eslint packages",
       "groupSlug": "eslint-packages"
     },
     {
@@ -22,7 +22,7 @@
         "prettier-package-json",
         "sort-package-json"
       ],
-      "groupName": "dependencies: code formatter packages",
+      "groupName": "code formatter packages",
       "groupSlug": "code-formatter-packages"
     },
     {
@@ -42,7 +42,7 @@
         "type-fest",
         "typescript-cached-transpile"
       ],
-      "groupName": "dependencies: test packages",
+      "groupName": "test packages",
       "groupSlug": "tester-packages"
     },
     {
@@ -55,7 +55,7 @@
         "patch-package",
         "rimraf"
       ],
-      "groupName": "dependencies: npm-scripts packages",
+      "groupName": "npm-scripts packages",
       "groupSlug": "npm-scripts-packages"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ CLI tool to generate `README.md` by using Nunjucks template file.
 ## Install
 
 ```sh
-npm install --save-dev github:sounisi5011/readme-generator#semver:0.0.7-rc.1
+npm install --save-dev github:sounisi5011/readme-generator
 ```
 
 ## Usage
@@ -66,11 +66,11 @@ Currently not supported.
 
 ### Default Defined Variables
 
-* `pkg` - [Source](https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/src/index.ts#L393)
+* `pkg` - [Source](https://github.com/sounisi5011/readme-generator/tree/master/src/index.ts#L393)
 
     Object value of `package.json`
 
-* `repo` - [Source](https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/src/index.ts#L454-L462)
+* `repo` - [Source](https://github.com/sounisi5011/readme-generator/tree/master/src/index.ts#L454-L462)
 
     Object value indicating repository data.
     It is generate by reading [the `repository` field] of [`package.json`].
@@ -78,7 +78,7 @@ Currently not supported.
 [`package.json`]: https://docs.npmjs.com/files/package.json
 [the `repository` field]: https://docs.npmjs.com/files/package.json#repository
 
-* `deps` - [Source](https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/src/index.ts#L528-L539)
+* `deps` - [Source](https://github.com/sounisi5011/readme-generator/tree/master/src/index.ts#L528-L539)
 
     Object value indicating dependencies data.
     It is generate by reading `package-lock.json`.
@@ -87,7 +87,7 @@ Currently not supported.
 
 #### `setProp`
 
-[Source](https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/src/template-tags/setProp.ts)
+[Source](https://github.com/sounisi5011/readme-generator/tree/master/src/template-tags/setProp.ts)
 
 `setProp` lets you create/modify variable properties.
 
@@ -167,7 +167,7 @@ node_modules/
 
 #### `omitPackageScope`
 
-[Source](https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/src/index.ts#L109-L114)
+[Source](https://github.com/sounisi5011/readme-generator/tree/master/src/index.ts#L109-L114)
 
 template:
 
@@ -183,7 +183,7 @@ bar
 
 #### `npmURL`
 
-[Source](https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/src/index.ts#L115-L132)
+[Source](https://github.com/sounisi5011/readme-generator/tree/master/src/index.ts#L115-L132)
 
 template:
 
@@ -215,7 +215,7 @@ output:
 
 #### `execCommand`
 
-[Source](https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/src/index.ts#L133-L160)
+[Source](https://github.com/sounisi5011/readme-generator/tree/master/src/index.ts#L133-L160)
 
 template:
 
@@ -235,7 +235,7 @@ v7.11.0
 
 #### `linesSelectedURL`
 
-[Source](https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/src/index.ts#L161-L314)
+[Source](https://github.com/sounisi5011/readme-generator/tree/master/src/index.ts#L161-L314)
 
 template:
 
@@ -265,20 +265,20 @@ template:
 output:
 
 ```
-11. https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/types.node_modules/npm-path.d.ts#L118
-21. https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/types.node_modules/npm-path.d.ts#L118
+11. https://github.com/sounisi5011/readme-generator/tree/master/types.node_modules/npm-path.d.ts#L118
+21. https://github.com/sounisi5011/readme-generator/tree/master/types.node_modules/npm-path.d.ts#L118
 
-12. https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/types.node_modules/npm-path.d.ts#L37-L40
-22. https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/types.node_modules/npm-path.d.ts#L40
+12. https://github.com/sounisi5011/readme-generator/tree/master/types.node_modules/npm-path.d.ts#L37-L40
+22. https://github.com/sounisi5011/readme-generator/tree/master/types.node_modules/npm-path.d.ts#L40
 
-13. https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/types.node_modules/npm-path.d.ts#L37-L39
-23. https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/types.node_modules/npm-path.d.ts#L39
+13. https://github.com/sounisi5011/readme-generator/tree/master/types.node_modules/npm-path.d.ts#L37-L39
+23. https://github.com/sounisi5011/readme-generator/tree/master/types.node_modules/npm-path.d.ts#L39
 
-34. https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/.eslintrc.yaml#L9-L11
-35. https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/.eslintrc.yaml#L9-L11
-36. https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/.eslintrc.yaml#L9-L10
+34. https://github.com/sounisi5011/readme-generator/tree/master/.eslintrc.yaml#L9-L11
+35. https://github.com/sounisi5011/readme-generator/tree/master/.eslintrc.yaml#L9-L11
+36. https://github.com/sounisi5011/readme-generator/tree/master/.eslintrc.yaml#L9-L10
 
-41. https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/.prettierrc.yaml#L2-L11
+41. https://github.com/sounisi5011/readme-generator/tree/master/.prettierrc.yaml#L2-L11
 
 51. http://example.com/path/to#L54
 ```
@@ -287,7 +287,7 @@ output:
 
 *This filter is only defined if the generator was able to read the remote repository from [the `repository` field] of [`package.json`]*.
 
-[Source](https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/src/index.ts#L478-L503)
+[Source](https://github.com/sounisi5011/readme-generator/tree/master/src/index.ts#L478-L503)
 
 template:
 
@@ -308,17 +308,17 @@ template:
 output:
 
 ```
-11. https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/.template/README.njk
+11. https://github.com/sounisi5011/readme-generator/tree/master/.template/README.njk
 12. https://github.com/sounisi5011/readme-generator/tree/foo/.template/README.njk
 13. https://github.com/sounisi5011/readme-generator/tree/gh-pages/.template/README.njk
 14. https://github.com/sounisi5011/readme-generator/tree/4626dfa/.template/README.njk
 15. https://github.com/sounisi5011/readme-generator/tree/COMMIT-ISH/.template/README.njk
 
-21. https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/.template/README.njk
+21. https://github.com/sounisi5011/readme-generator/tree/master/.template/README.njk
 
-31. https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/.template/README.njk
+31. https://github.com/sounisi5011/readme-generator/tree/master/.template/README.njk
 
-41. https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/src/index.ts
+41. https://github.com/sounisi5011/readme-generator/tree/master/src/index.ts
 ```
 
 #### `isOlderReleasedVersion`
@@ -341,7 +341,7 @@ There are three types of return values:
     * If the current directory is not a git repository.
     * Run the `git init` command, then haven't first committed yet.
 
-[Source](https://github.com/sounisi5011/readme-generator/tree/v0.0.7-rc.1/src/index.ts#L466-L477)
+[Source](https://github.com/sounisi5011/readme-generator/tree/master/src/index.ts#L466-L477)
 
 template:
 
@@ -355,7 +355,7 @@ output:
 
 ```
 0.0.2: true
-0.0.7-rc.1: false
+0.0.7-rc.1: true
 999.90.1: false
 ```
 


### PR DESCRIPTION
Reverts #83

The [conventional-changelog] does not write devDependencies package updates to the `CHANGELOG`.
Therefore, the PRs for multiple package updates specified in the devDependencies created by [Renovate] should be grouped into one.

[conventional-changelog]: https://github.com/conventional-changelog/conventional-changelog
[Renovate]: https://renovatebot.com/
