### PR TITLE
test(jest): replace option `tsConfig` for ts-jest with `tsconfig`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   coverageDirectory: 'coverage',
   globals: {
     'ts-jest': {
-      tsConfig: '<rootDir>/tests/tsconfig.json',
+      tsconfig: '<rootDir>/tests/tsconfig.json',
     },
   },
   setupFilesAfterEnv: [


### PR DESCRIPTION
Since `ts-jest@26.4.2`, the `tsConfig` option has been deprecated.